### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,18 @@
   	
 	<build>
 		<plugins>
+			
+			<plugin>
+              			<groupId>org.apache.maven.plugins</groupId>
+              			<artifactId>maven-compiler-plugin</artifactId>
+              			<version>3.5.1</version>
+              			<configuration>
+					<source>1.5</source>
+					<target>1.5</target>
+              			</configuration>
+	    		</plugin>
+
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 			    <artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION
Maven fails because default Java Compiler setting is < 1.5
http://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html
